### PR TITLE
Add C++ namespace example

### DIFF
--- a/CPlusPlus/Modularity/NamespaceParticles/Makefile
+++ b/CPlusPlus/Modularity/NamespaceParticles/Makefile
@@ -1,0 +1,18 @@
+CXX = g++
+CXXFLAGS = -std=c++14 -g -O2 -Wall -Wextra
+CPPFLAGS = -MMD -MP
+LDLIBS = -lm
+
+all: particles.exe
+
+particles.exe: particle.o particles_main.o
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDLIBS)
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c -o $@ $<
+
+-include $(wildcard *.d)
+
+clean:
+	$(RM) $(wildcard *.exe) $(wildcard *.o) $(wildcard *.d)
+	$(RM) core $(wildcard core.)

--- a/CPlusPlus/Modularity/NamespaceParticles/README.md
+++ b/CPlusPlus/Modularity/NamespaceParticles/README.md
@@ -1,0 +1,10 @@
+# NamespaceParticles
+Example of using a namespace.
+
+# What is it?
+1. `particle.h`: declaration of the `Particle` class in the namespace `particle`.
+1. `particle.cpp`: implementation of the `Particle` class in the namespace
+   `particle`..
+1. `particles_main.cpp`: main function for the particles application, using the
+   `Particle` class in namespace `particle`.
+1. `Makefile`: make file for these examples.

--- a/CPlusPlus/Modularity/NamespaceParticles/particle.cpp
+++ b/CPlusPlus/Modularity/NamespaceParticles/particle.cpp
@@ -1,0 +1,29 @@
+#include <cmath>
+#include <iostream>
+
+#include "particle.h"
+
+namespace particle {
+
+    inline double sqr(double x) {
+        return x*x;
+    }
+
+    void Particle::move(double dx, double dy, double dz) {
+        x_ += dx;
+        y_ += dy;
+        z_ += dz;
+    }
+
+    double Particle::dist(const Particle& other) const {
+        return sqrt(sqr(x_ - other.x()) + 
+                    sqr(y_ - other.y()) +
+                    sqr(z_ - other.z()));
+    }
+
+    std::ostream& operator<<(std::ostream& out, const Particle& p) {
+        return out << "(" << p.x() << ", " << p.y() << ", " << p.z() << ")"
+               << ", mass = " << p.mass();
+    }
+
+};

--- a/CPlusPlus/Modularity/NamespaceParticles/particle.h
+++ b/CPlusPlus/Modularity/NamespaceParticles/particle.h
@@ -1,0 +1,26 @@
+#include <functional>
+#include <iostream>
+
+namespace particle {
+
+    class Particle {
+        private:
+            double x_, y_, z_;
+            double mass_;
+        public:
+            Particle(std::function<double()> pos_distr,
+                     std::function<double()> mass_distr) :
+                x_ {pos_distr()},
+                y_ {pos_distr()},
+                z_ {pos_distr()},
+                mass_ {mass_distr()} {};
+            double x() const { return x_; }
+            double y() const { return y_; }
+            double z() const { return z_; }
+            double mass() const {return mass_; }
+            void move(double dx, double dy, double dz);
+            double dist(const Particle& other) const;
+            friend std::ostream& operator<<(std::ostream& out, const Particle& p);
+    };
+
+};

--- a/CPlusPlus/Modularity/NamespaceParticles/particles_main.cpp
+++ b/CPlusPlus/Modularity/NamespaceParticles/particles_main.cpp
@@ -1,0 +1,24 @@
+#include <functional>
+#include <iostream>
+#include <random>
+
+#include "particle.h"
+
+using particle::Particle;
+
+int main() {
+    auto engine {std::mt19937_64(1234)};
+    auto pos_distr = std::bind(std::uniform_real_distribution<double>(-1.0, 1.0),
+                               std::ref(engine));
+    auto mass_distr = std::bind(std::uniform_real_distribution<double>(0.0, 1.0),
+                                std::ref(engine));
+    Particle p1(pos_distr, mass_distr);
+    Particle p2(pos_distr, mass_distr);
+    std::cout << p1 << std::endl << p2 << std::endl;
+    p1.move(0.5, 0.5, 0.5);
+    std::cout << "moved: " << p1 << std::endl;
+    std::cout << "x = " << p1.x() << ", y = " << p1.y() << ", z = " << p1.z()
+              << std::endl;
+    std::cout << "distance = " << p1.dist(p2) << std::endl;
+    return 0;
+}

--- a/CPlusPlus/Modularity/README.md
+++ b/CPlusPlus/Modularity/README.md
@@ -3,6 +3,7 @@ Code illustrations for chapter 3, Modularity in Stroustrup's
 "A tour of C++".
 
 # What is it?
+1. `NamespaceParticles`: example of defining a namespace.
 1. `Patricles`: example of separate compilation.
 1. `Stats`: example of separate compilation.
 1. `fac.cpp`: illustrates exception handling.


### PR DESCRIPTION
Why:

* No sample code for user defined namespaces was included in the repository.

This change addresses the need by:

* C++ training